### PR TITLE
Migrate dependency management to `uv` and add mock-based unit tests for Spartan

### DIFF
--- a/tests/spartan/test_unit_mocked.py
+++ b/tests/spartan/test_unit_mocked.py
@@ -1,0 +1,75 @@
+from importlib import import_module
+from queue import Queue
+from unittest.mock import MagicMock, patch
+import typing
+
+if not hasattr(typing, "Self"):
+    typing.Self = typing.Any  # type: ignore[attr-defined]
+
+from sekit.spartan.Cluster import Cluster
+from sekit.spartan.ComputeNode import ComputeNode
+from sekit.spartan.SshComputeNode import SshComputeNode, SshComputeNodeThread
+
+ssh_module = import_module("sekit.spartan.SshComputeNode")
+
+
+def test_compute_node_start_setup_accepts_iterable() -> None:
+    cn = ComputeNode(n_jobs=1)
+    cn._start_setup(["echo 1", "echo 2"])
+
+    assert isinstance(cn.q_commands, Queue)
+    assert cn.q_commands.qsize() == 2
+
+
+def test_compute_node_allocate_and_release_device() -> None:
+    cn = ComputeNode(device=["cuda:0", "cuda:1"])
+
+    key, allocated = cn.allocate_device()
+
+    assert key == "_device"
+    assert allocated == "cuda:0"
+    assert cn.device_state[allocated] == 1
+
+    cn.release_device(allocated)
+    assert cn.device_state[allocated] == 0
+
+
+def test_cluster_update_compute_node_changes_interval_and_devices() -> None:
+    cn = ComputeNode(n_jobs=1, device=["cuda:0"])
+    cluster = Cluster(compute_nodes=[cn], interval=1)
+
+    cluster.update_compute_node(
+        hostname="localhost", n_jobs=None, interval=2, devices=["cuda:1"]
+    )
+
+    assert cn.n_jobs == 1
+    assert list(cn.device_state.keys()) == ["cuda:1"]
+    assert cluster.interval == 2
+
+
+def test_ssh_compute_node_uses_remote_cpu_count_when_n_jobs_minus_one() -> None:
+    with patch.object(ssh_module, "getoutput", return_value="8") as mock_getoutput:
+        scn = SshComputeNode(hostname="test-ssh-server", n_jobs=-1)
+
+    assert scn.n_jobs == 8
+    mock_getoutput.assert_called_once()
+
+
+def test_ssh_thread_wraps_commands_with_ssh_prefix() -> None:
+    mock_proc = MagicMock()
+
+    with patch.object(ssh_module, "Popen", return_value=mock_proc) as mock_popen:
+        scn = SshComputeNode(
+            hostname="test-ssh-server", pre_cmd="source .profile"
+        )
+        thread = SshComputeNodeThread(p_cn=scn, name="ssh_thread")
+        thread.cmd = "python run.py --x 1; echo done"
+
+        proc = thread.exe_command()
+
+    assert proc is mock_proc
+    called_cmd = mock_popen.call_args.args[0]
+    assert "ssh test-ssh-server" in called_cmd
+    assert "'source .profile ; python run.py --x 1;'" in called_cmd
+    assert "'source .profile ;  echo done;'" in called_cmd
+    assert mock_popen.call_args.kwargs["shell"] is True


### PR DESCRIPTION
### Motivation
- 現在 `poetry` で管理している依存/ビルド設定を `uv`（PEP 621 + dependency-groups）へ移行して開発ワークフローを統一するため。
- コンテナ/SSH に依存する統合テストだけでなく、外部環境に依存しない単体テスト（Mockベース）を追加してローカルでの検証性を向上させるため。 

### Description
- `pyproject.toml` を Poetry フォーマットから PEP 621 形式へ書き換えし、`[project]` / `dependency-groups.dev` を定義して `hatchling` をビルドバックエンドに設定した（ブランチ: `feat/uv-migration`）。
- 開発者向け `README.md` のテスト実行手順を `uv sync --group dev` / `uv run pytest` に更新した（`poetry.lock` は削除）。
- `tests/spartan/test_unit_mocked.py` を追加して、`ComputeNode` / `Cluster` / `SshComputeNode` / `SshComputeNodeThread` の主要動作を Mock による単体テストで検証できるようにした（ブランチ: `feat/mock-based-unit-tests`）。
- Python 3.10 環境での互換性問題を回避するため、テストファイル内で `typing.Self` が無ければ代替定義を注入する互換処理を追加した。 

### Testing
- `python -m pytest tests/spartan/test_unit_mocked.py` を実行し `5 passed` で成功した。 
- `python -m pytest tests/test_utils.py` は当初 `typing.Self` による ImportError が発生して失敗したため互換処理を導入して対処した。 
- `uv lock` によるロック生成はこの実行環境で PyPI への接続が制限されており `Failed to fetch` エラーになったため実行不可だった。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699197ca0944832cb474306127aded06)