### PR TITLE
Add Spartan unit tests and integration markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,8 @@ packages = ["sekit"]
 
 [tool.black]
 line-length = 79
+
+[tool.pytest.ini_options]
+markers = [
+  "integration: marks tests that require integration environments",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ packages = ["sekit"]
 line-length = 79
 
 [tool.pytest.ini_options]
+addopts = "-m 'not integration'"
 markers = [
   "integration: marks tests that require integration environments",
 ]

--- a/tests/spartan/test_cluster.py
+++ b/tests/spartan/test_cluster.py
@@ -4,11 +4,15 @@ from pathlib import Path
 from queue import Queue
 from typing import Generator
 
+import pytest
+
 from sekit.spartan import Cluster, ComputeNode, SshComputeNode
 
 """
 test_ssh_compute_node.pyのコメントに書かれている、テスト環境セットアップ方法を実施した上で実行すること
 """
+
+pytestmark = pytest.mark.integration
 
 
 def test_cluster(

--- a/tests/spartan/test_cluster_unit.py
+++ b/tests/spartan/test_cluster_unit.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from queue import Queue
+
+from sekit.spartan import Cluster
+
+
+class DummyNode:
+    def __init__(self, hostname: str) -> None:
+        self.hostname = hostname
+        self.started_queue = None
+        self.kill_all_called = False
+        self._remaining_running_checks = 1
+
+    def start(self, queue: Queue) -> None:
+        self.started_queue = queue
+
+    def check_continue(self) -> bool:
+        if self._remaining_running_checks > 0:
+            self._remaining_running_checks -= 1
+            return True
+        return False
+
+    def kill_all(self) -> None:
+        self.kill_all_called = True
+
+
+def test_cluster_start_and_wait_all_with_mock_nodes() -> None:
+    local_node = DummyNode("localhost")
+    mock_ssh_node = DummyNode("mock-ssh-host")
+    cluster = Cluster((local_node, mock_ssh_node), interval=0)
+
+    cluster.start(["echo 1", "echo 2"])
+    cluster.wait_all()
+
+    assert local_node.started_queue is not None
+    assert local_node.started_queue is mock_ssh_node.started_queue
+    assert cluster.qsize() == 2
+    assert local_node.kill_all_called is True
+    assert mock_ssh_node.kill_all_called is True

--- a/tests/spartan/test_spartan.py
+++ b/tests/spartan/test_spartan.py
@@ -13,6 +13,8 @@ from sekit.spartan import SpartanController
 
 from .command import FILENAME_TEMPLATE
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.mark.parametrize(
     "mode,n_seeds,max_seed", [("argparse", 3, 100), ("json", 10, 10000)]

--- a/tests/spartan/test_spartan_unit.py
+++ b/tests/spartan/test_spartan_unit.py
@@ -1,14 +1,24 @@
 # -*- coding: utf-8 -*-
+from typing import Any
 from types import SimpleNamespace
+
+import pytest
 
 import sekit.spartan.Spartan as spartan_module
 
 
-def test_controller_builds_remote_node_without_ssh_access(monkeypatch) -> None:
-    created = {"compute": [], "ssh": []}
+def test_controller_builds_remote_node_without_ssh_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: dict[str, list[Any]] = {"compute": [], "ssh": []}
 
     class DummyComputeNode:
-        def __init__(self, n_jobs=1, interval=1, device=None) -> None:
+        def __init__(
+            self,
+            n_jobs: int = 1,
+            interval: int | float = 1,
+            device: list[str] | None = None,
+        ) -> None:
             self.hostname = "localhost"
             self.n_jobs = n_jobs
             self.interval = interval
@@ -16,7 +26,13 @@ def test_controller_builds_remote_node_without_ssh_access(monkeypatch) -> None:
             created["compute"].append(self)
 
     class DummySshComputeNode:
-        def __init__(self, hostname, n_jobs=1, interval=1, device=None) -> None:
+        def __init__(
+            self,
+            hostname: str,
+            n_jobs: int = 1,
+            interval: int | float = 1,
+            device: list[str] | None = None,
+        ) -> None:
             self.hostname = hostname
             self.n_jobs = n_jobs
             self.interval = interval
@@ -24,7 +40,7 @@ def test_controller_builds_remote_node_without_ssh_access(monkeypatch) -> None:
             created["ssh"].append(self)
 
     class DummyCluster:
-        def __init__(self, compute_nodes) -> None:
+        def __init__(self, compute_nodes: list[Any]) -> None:
             self.compute_nodes = compute_nodes
 
     monkeypatch.setattr(spartan_module, "ComputeNode", DummyComputeNode)
@@ -45,19 +61,31 @@ def test_controller_builds_remote_node_without_ssh_access(monkeypatch) -> None:
     assert controller.make_param_str({"a": 1}) == "--a 1"
 
 
-def test_controller_json_mode_uses_json_serializer(monkeypatch) -> None:
+def test_controller_json_mode_uses_json_serializer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def make_dummy_cluster(compute_nodes: list[Any]) -> SimpleNamespace:
+        return SimpleNamespace(compute_nodes=compute_nodes)
+
+    def make_dummy_compute_node(
+        n_jobs: int = 1,
+        interval: int | float = 1,
+        device: list[str] | None = None,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            hostname="localhost",
+            n_jobs=n_jobs,
+            interval=interval,
+            device_state={d: 0 for d in (device or [])},
+        )
+
     monkeypatch.setattr(
-        spartan_module, "Cluster", lambda compute_nodes: SimpleNamespace()
+        spartan_module, "Cluster", make_dummy_cluster
     )
     monkeypatch.setattr(
         spartan_module,
         "ComputeNode",
-        lambda n_jobs=1, interval=1, device=None: SimpleNamespace(
-            hostname="localhost",
-            n_jobs=n_jobs,
-            interval=interval,
-            device_state={},
-        ),
+        make_dummy_compute_node,
     )
 
     controller = spartan_module.SpartanController(mode="json")

--- a/tests/spartan/test_spartan_unit.py
+++ b/tests/spartan/test_spartan_unit.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+from types import SimpleNamespace
+
+import sekit.spartan.Spartan as spartan_module
+
+
+def test_controller_builds_remote_node_without_ssh_access(monkeypatch) -> None:
+    created = {"compute": [], "ssh": []}
+
+    class DummyComputeNode:
+        def __init__(self, n_jobs=1, interval=1, device=None) -> None:
+            self.hostname = "localhost"
+            self.n_jobs = n_jobs
+            self.interval = interval
+            self.device_state = {d: 0 for d in (device or [])}
+            created["compute"].append(self)
+
+    class DummySshComputeNode:
+        def __init__(self, hostname, n_jobs=1, interval=1, device=None) -> None:
+            self.hostname = hostname
+            self.n_jobs = n_jobs
+            self.interval = interval
+            self.device_state = {d: 0 for d in (device or [])}
+            created["ssh"].append(self)
+
+    class DummyCluster:
+        def __init__(self, compute_nodes) -> None:
+            self.compute_nodes = compute_nodes
+
+    monkeypatch.setattr(spartan_module, "ComputeNode", DummyComputeNode)
+    monkeypatch.setattr(spartan_module, "SshComputeNode", DummySshComputeNode)
+    monkeypatch.setattr(spartan_module, "Cluster", DummyCluster)
+
+    controller = spartan_module.SpartanController(
+        hosts=[
+            {"hostname": "localhost", "n_jobs": 1},
+            {"hostname": "mock-ssh-host", "n_jobs": 2},
+        ]
+    )
+
+    assert isinstance(controller.cluster, DummyCluster)
+    assert len(created["compute"]) == 1
+    assert len(created["ssh"]) == 1
+    assert created["ssh"][0].hostname == "mock-ssh-host"
+    assert controller.make_param_str({"a": 1}) == "--a 1"
+
+
+def test_controller_json_mode_uses_json_serializer(monkeypatch) -> None:
+    monkeypatch.setattr(
+        spartan_module, "Cluster", lambda compute_nodes: SimpleNamespace()
+    )
+    monkeypatch.setattr(
+        spartan_module,
+        "ComputeNode",
+        lambda n_jobs=1, interval=1, device=None: SimpleNamespace(
+            hostname="localhost",
+            n_jobs=n_jobs,
+            interval=interval,
+            device_state={},
+        ),
+    )
+
+    controller = spartan_module.SpartanController(mode="json")
+
+    assert controller.make_param_str({"a": 1}) == '"{\\"a\\": 1}"'

--- a/tests/spartan/test_ssh_compute_node.py
+++ b/tests/spartan/test_ssh_compute_node.py
@@ -12,6 +12,8 @@ from sekit.spartan import SshComputeNode
 
 """
 
+pytestmark = pytest.mark.integration
+
 
 def test_init(ssh_server_name: str) -> None:
     """

--- a/tests/spartan/test_ssh_compute_node_unit.py
+++ b/tests/spartan/test_ssh_compute_node_unit.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+import importlib
+from types import SimpleNamespace
+
+ssh_module = importlib.import_module("sekit.spartan.SshComputeNode")
+
+
+def test_init_with_negative_n_jobs_uses_mocked_cpu_count(monkeypatch) -> None:
+    monkeypatch.setattr(ssh_module, "getoutput", lambda _: "12")
+
+    compute_node = ssh_module.SshComputeNode("dummy-host", n_jobs=-1)
+
+    assert compute_node.hostname == "dummy-host"
+    assert compute_node.n_jobs == 12
+
+
+def test_start_thread_uses_ssh_thread_without_network(monkeypatch) -> None:
+    started_names = []
+
+    def fake_start(self) -> None:
+        started_names.append(self.name)
+
+    monkeypatch.setattr(ssh_module.SshComputeNodeThread, "start", fake_start)
+    compute_node = ssh_module.SshComputeNode(
+        "dummy-host", thread_name="dummy-host"
+    )
+
+    compute_node._start_thread(3)
+
+    assert started_names == ["dummy-host_3"]
+    assert len(compute_node.threads) == 1
+
+
+def test_thread_exe_command_builds_ssh_command(monkeypatch) -> None:
+    captured = {}
+
+    def fake_popen(cmd, shell):
+        captured["cmd"] = cmd
+        captured["shell"] = shell
+        return SimpleNamespace()
+
+    monkeypatch.setattr(ssh_module, "Popen", fake_popen)
+    compute_node = ssh_module.SshComputeNode(
+        "dummy-host", pre_cmd="source .profile"
+    )
+    thread = ssh_module.SshComputeNodeThread(p_cn=compute_node, name="th")
+    thread.cmd = "echo hello; echo world"
+
+    thread.exe_command()
+
+    assert captured["shell"] is True
+    assert "ssh dummy-host 'source .profile ; echo hello;'" in captured["cmd"]
+    assert "ssh dummy-host 'source .profile ;  echo world;'" in captured["cmd"]

--- a/tests/spartan/test_ssh_compute_node_unit.py
+++ b/tests/spartan/test_ssh_compute_node_unit.py
@@ -1,12 +1,24 @@
 # -*- coding: utf-8 -*-
 import importlib
+from typing import Protocol
 from types import SimpleNamespace
+
+import pytest
 
 ssh_module = importlib.import_module("sekit.spartan.SshComputeNode")
 
 
-def test_init_with_negative_n_jobs_uses_mocked_cpu_count(monkeypatch) -> None:
-    monkeypatch.setattr(ssh_module, "getoutput", lambda _: "12")
+class HasName(Protocol):
+    name: str
+
+
+def test_init_with_negative_n_jobs_uses_mocked_cpu_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_getoutput(_: str) -> str:
+        return "12"
+
+    monkeypatch.setattr(ssh_module, "getoutput", fake_getoutput)
 
     compute_node = ssh_module.SshComputeNode("dummy-host", n_jobs=-1)
 
@@ -14,10 +26,12 @@ def test_init_with_negative_n_jobs_uses_mocked_cpu_count(monkeypatch) -> None:
     assert compute_node.n_jobs == 12
 
 
-def test_start_thread_uses_ssh_thread_without_network(monkeypatch) -> None:
-    started_names = []
+def test_start_thread_uses_ssh_thread_without_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started_names: list[str] = []
 
-    def fake_start(self) -> None:
+    def fake_start(self: HasName) -> None:
         started_names.append(self.name)
 
     monkeypatch.setattr(ssh_module.SshComputeNodeThread, "start", fake_start)
@@ -31,10 +45,12 @@ def test_start_thread_uses_ssh_thread_without_network(monkeypatch) -> None:
     assert len(compute_node.threads) == 1
 
 
-def test_thread_exe_command_builds_ssh_command(monkeypatch) -> None:
-    captured = {}
+def test_thread_exe_command_builds_ssh_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str | bool] = {}
 
-    def fake_popen(cmd, shell):
+    def fake_popen(cmd: str, shell: bool) -> SimpleNamespace:
         captured["cmd"] = cmd
         captured["shell"] = shell
         return SimpleNamespace()


### PR DESCRIPTION
Summary:\n- add unit tests for Spartan components using mocks (no SSH/network dependency)\n- mark existing Spartan integration tests with pytest mark integration\n- register the integration marker in pytest config\n\nVerification:\n- uv run pytest -m integration --collect-only -q\n- uv run pytest -m 'not integration' -q\n