### PR TITLE
Use forward reference for ComputeNodeThread parent type

### DIFF
--- a/sekit/spartan/ComputeNode.py
+++ b/sekit/spartan/ComputeNode.py
@@ -11,7 +11,7 @@ from typing import Any, Iterable, Sequence, cast
 class ComputeNodeThread(Thread):
     def __init__(
         self,
-        p_cn: ComputeNode,
+        p_cn: "ComputeNode",
         timeout: int | float | None = 1,
         name: str = "Thread",
     ) -> None:


### PR DESCRIPTION
Summary:\n- switch ComputeNodeThread constructor annotation from ComputeNode to forward reference string\n- keep behavior unchanged; this is a typing-safety style update\n\nVerification:\n- uv run mypy --strict sekit/spartan/ComputeNode.py\n- uv run ruff check sekit/spartan/ComputeNode.py\n- uv run pytest tests/spartan/test_compute_node.py tests/spartan/test_cluster_unit.py -q\n