### PR TITLE
Make tests and examples pass mypy --strict

### DIFF
--- a/examples/example_eio_1.py
+++ b/examples/example_eio_1.py
@@ -6,7 +6,7 @@ from sekit.eio import eio
 def example_eio_1(
     hidden_layer_sizes: list[int], activation: str, validation_fraction: float
 ) -> dict[str, list[int] | str | float]:
-    dict_out = {
+    dict_out: dict[str, list[int] | str | float] = {
         "a": [a * 2 for a in hidden_layer_sizes],
         "b": "___" + activation + "___",
         "c": validation_fraction * 3,

--- a/examples/example_eio_2.py
+++ b/examples/example_eio_2.py
@@ -7,8 +7,8 @@ from sekit.eio import eio
 @eio()
 def example_eio_2(
     hidden_layer_sizes: list[int], activation: str, validation_fraction: float
-) -> tuple[dict[str, list[int] | str | float] | pd.DataFrame]:
-    dict_out = {
+) -> tuple[dict[str, list[int] | str | float], pd.DataFrame]:
+    dict_out: dict[str, list[int] | str | float] = {
         "a": [a * 2 for a in hidden_layer_sizes],
         "b": "___" + activation + "___",
         "c": validation_fraction * 3,

--- a/examples/search_inputs/command.py
+++ b/examples/search_inputs/command.py
@@ -7,15 +7,15 @@ from pathlib import Path
 from sekit.eio import eio
 
 
-@eio(out_dir=Path(__file__).parent)
+@eio(out_dir=str(Path(__file__).parent))
 def sample(
-    hidden_layer_sizes: tuple,
+    hidden_layer_sizes: tuple[int, ...],
     activation: str,
     validation_fraction: float,
     _seed: int,
-) -> dict:
+) -> dict[str, float | str | list[float]]:
     random.seed(_seed)
-    dict_out = {
+    dict_out: dict[str, float | str | list[float]] = {
         "hoge": sum([a * 2 + random.random() for a in hidden_layer_sizes]),
         "goro": "___" + activation + "___",
         "piyo": validation_fraction * 3 + random.random(),

--- a/examples/spartan_command.py
+++ b/examples/spartan_command.py
@@ -6,7 +6,7 @@ from argparse import ArgumentParser
 
 def exe(a: float, b: str, _seed: int) -> str:
     random.seed(_seed)
-    s = 0
+    s = 0.0
     c = random.randint(1, 3)
     for _ in range(int(a * (c * 10**8))):
         s += a

--- a/examples/spartan_gpu_command.py
+++ b/examples/spartan_gpu_command.py
@@ -8,7 +8,7 @@ device = None
 
 def exe(a: float, b: str, _seed: int) -> str:
     random.seed(_seed)
-    s = 0
+    s = 0.0
     c = random.randint(1, 3)
     for _ in range(int(a * (c * 10**8))):
         s += a

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 
 
 @pytest.fixture(scope="module")
-def search_filepath_list() -> list:
+def search_filepath_list() -> list[str]:
     here = Path(__file__).parent
     pattern = str(here / "data" / "results" / "*.json")
     filepath_list = [filepath for filepath in glob.glob(pattern)]
@@ -16,8 +16,8 @@ def search_filepath_list() -> list:
 
 
 @pytest.fixture
-def out_func_hoge_piyo() -> tuple[str, Callable[dict[str, int], int]]:
-    def _func_hoge_piyo(result: dict) -> int:
+def out_func_hoge_piyo() -> tuple[str, Callable[[dict[str, int]], int]]:
+    def _func_hoge_piyo(result: dict[str, int]) -> int:
         return result["hoge"] + result["piyo"]
 
     return ("hoge+piyo", _func_hoge_piyo)

--- a/tests/spartan/conftest.py
+++ b/tests/spartan/conftest.py
@@ -42,7 +42,7 @@ def ssh_tmp_dir(
 
 @pytest.fixture
 def local_and_ssh_tmp_dir(
-    ssh_server_name: str, tmp_dir: Generator[Path, None, None]
+    ssh_server_name: str, tmp_dir: Path
 ) -> Generator[tuple[str, Path], None, None]:
     """
     ローカルとSSHサーバの両方に同じ名前のディレクトリを作成して返すディレクトリ

--- a/tests/spartan/test_cluster.py
+++ b/tests/spartan/test_cluster.py
@@ -2,7 +2,6 @@
 import subprocess
 from pathlib import Path
 from queue import Queue
-from typing import Generator
 
 import pytest
 
@@ -16,7 +15,7 @@ pytestmark = pytest.mark.integration
 
 
 def test_cluster(
-    local_and_ssh_tmp_dir: Generator[Path, None, None], interval: float
+    local_and_ssh_tmp_dir: tuple[str, Path], interval: float
 ) -> None:
     n_made_files = 100
     # ローカルとSSH先の両方で１回以上実行されるくらいの数
@@ -29,7 +28,7 @@ def test_cluster(
     cluster = Cluster(compute_nodes)
     filepath_list = [tmp_dir_path / f"{i}.txt" for i in range(n_made_files)]
     commands = ["touch " + str(fp) for fp in filepath_list]
-    q_commands = Queue()
+    q_commands: Queue[str] = Queue()
     for c in commands:
         q_commands.put(c)
     cluster.start(q_commands)

--- a/tests/spartan/test_cluster_unit.py
+++ b/tests/spartan/test_cluster_unit.py
@@ -1,17 +1,18 @@
 # -*- coding: utf-8 -*-
 from queue import Queue
+from typing import cast
 
-from sekit.spartan import Cluster
+from sekit.spartan import Cluster, ComputeNode
 
 
 class DummyNode:
     def __init__(self, hostname: str) -> None:
         self.hostname = hostname
-        self.started_queue = None
+        self.started_queue: Queue[str] | None = None
         self.kill_all_called = False
         self._remaining_running_checks = 1
 
-    def start(self, queue: Queue) -> None:
+    def start(self, queue: Queue[str]) -> None:
         self.started_queue = queue
 
     def check_continue(self) -> bool:
@@ -27,7 +28,8 @@ class DummyNode:
 def test_cluster_start_and_wait_all_with_mock_nodes() -> None:
     local_node = DummyNode("localhost")
     mock_ssh_node = DummyNode("mock-ssh-host")
-    cluster = Cluster((local_node, mock_ssh_node), interval=0)
+    compute_nodes = cast(tuple[ComputeNode, ComputeNode], (local_node, mock_ssh_node))
+    cluster = Cluster(compute_nodes, interval=0)
 
     cluster.start(["echo 1", "echo 2"])
     cluster.wait_all()

--- a/tests/spartan/test_compute_node.py
+++ b/tests/spartan/test_compute_node.py
@@ -2,7 +2,6 @@
 from multiprocessing import cpu_count
 from pathlib import Path
 from queue import Queue
-from typing import Generator
 
 import pytest
 
@@ -23,7 +22,7 @@ def test_init() -> None:
 
 @pytest.mark.parametrize("n_exe", [1, 5, 10])
 def test_start(
-    tmp_dir: Generator[Path, None, None], n_exe: int, interval: float
+    tmp_dir: Path, n_exe: int, interval: float
 ) -> None:
     """
     実行したいコマンドが実行されるかのテスト
@@ -35,7 +34,7 @@ def test_start(
     filename_list = [f"___test_{i}" for i in range(n_exe)]
     filepath_list = [out_dir / fn for fn in filename_list]
     commands = [f"touch {fp}" for fp in filepath_list]
-    q_commands = Queue()
+    q_commands: Queue[str] = Queue()
     for c in commands:
         q_commands.put(c)
     cn.start(q_commands)
@@ -46,8 +45,8 @@ def test_start(
 
 @pytest.mark.parametrize("device", (["mps"], ["cuda:0", "cuda:1"]))
 def test_device(
-    device: list[str], tmp_dir: Generator[Path, None, None], interval: float
-):
+    device: list[str], tmp_dir: Path, interval: float
+) -> None:
     """
     GPU等のdeviceの設定をコマンドに付与できるかのテスト.
     TODO: そもそもの構造として、ComputeNodeにこのテストがいるかは要検討.
@@ -61,7 +60,7 @@ def test_device(
     out_dir = tmp_dir
     outpath_list = [str(out_dir / f"device_info_{i}.txt") for i in range(5)]
     commands = [exe + outpath for outpath in outpath_list]
-    q_commands = Queue()
+    q_commands: Queue[str] = Queue()
     for c in commands:
         q_commands.put(c)
     cn.start(q_commands)

--- a/tests/spartan/test_spartan.py
+++ b/tests/spartan/test_spartan.py
@@ -5,7 +5,6 @@ import shutil
 import subprocess
 from itertools import chain, product
 from pathlib import Path
-from typing import Generator
 
 import pytest
 
@@ -23,7 +22,7 @@ def test_spartan(
     mode: str,
     n_seeds: int,
     max_seed: int,
-    local_and_ssh_tmp_dir: Generator[Path, None, None],
+    local_and_ssh_tmp_dir: tuple[str, Path],
     interval: float,
 ) -> None:
     # ローカルとSSH先に実行するpythonファイルのコピー
@@ -33,7 +32,7 @@ def test_spartan(
     shutil.copy(source_command_path, exe_path)
     scp_command = [
         "scp",
-        source_command_path,
+        str(source_command_path),
         f"{ssh_server_name}:{tmp_dir_path}/",
     ]
     subprocess.run(scp_command)
@@ -47,7 +46,7 @@ def test_spartan(
         },
         {"a": [3], "b": ["giro"], "out_dir": [str(tmp_dir_path)]},
     ]
-    hosts = [
+    hosts: list[dict[str, str | int | float]] = [
         {"hostname": "localhost", "n_jobs": 1},
         {"hostname": ssh_server_name, "n_jobs": 1},
     ]

--- a/tests/spartan/test_ssh_compute_node.py
+++ b/tests/spartan/test_ssh_compute_node.py
@@ -2,7 +2,6 @@
 import subprocess
 from pathlib import Path
 from queue import Queue
-from typing import Generator
 
 import pytest
 
@@ -32,7 +31,7 @@ def test_init(ssh_server_name: str) -> None:
 
 @pytest.mark.parametrize("n_exe", [1, 5, 10])
 def test_start(
-    ssh_tmp_dir: Generator[tuple[str, Path], None, None],
+    ssh_tmp_dir: tuple[str, Path],
     n_exe: int,
     interval: float,
 ) -> None:
@@ -52,7 +51,7 @@ def test_start(
     filename_list = [f"___test_{i}" for i in range(n_exe)]
     filepath_list = [out_dir / fn for fn in filename_list]
     commands = [f"touch {fp}" for fp in filepath_list]
-    q_commands = Queue()
+    q_commands: Queue[str] = Queue()
     for c in commands:
         q_commands.put(c)
     scn.start(q_commands)
@@ -66,8 +65,8 @@ def test_start(
 
 @pytest.mark.parametrize("device", (["mps"], ["cuda:0", "cuda:1"]))
 def test_device(
-    device: str,
-    ssh_tmp_dir: Generator[tuple[str, Path], None, None],
+    device: list[str],
+    ssh_tmp_dir: tuple[str, Path],
     interval: float,
 ) -> None:
     """
@@ -84,7 +83,7 @@ def test_device(
     exe = "python3 " + str(tmp_dir / "write_device_info.py ")
     outpath_list = [str(tmp_dir / f"device_info_{i}.txt") for i in range(5)]
     commands = [exe + outpath for outpath in outpath_list]
-    q_commands = Queue()
+    q_commands: Queue[str] = Queue()
 
     scn = SshComputeNode(
         ssh_server_name,
@@ -99,9 +98,8 @@ def test_device(
     scn.wait_all()
     for read_path in outpath_list:
         ssh_command = ["ssh", ssh_server_name, "cat", read_path]
-        assert (
-            subprocess.run(
-                ssh_command, encoding="utf-8", stdout=subprocess.PIPE
-            ).stdout
-            in device
-        )
+        stdout = subprocess.run(
+            ssh_command, encoding="utf-8", stdout=subprocess.PIPE
+        ).stdout
+        assert stdout is not None
+        assert stdout in device

--- a/tests/spartan/test_ssh_compute_node_unit.py
+++ b/tests/spartan/test_ssh_compute_node_unit.py
@@ -48,11 +48,13 @@ def test_start_thread_uses_ssh_thread_without_network(
 def test_thread_exe_command_builds_ssh_command(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured: dict[str, str | bool] = {}
+    captured_cmd = ""
+    captured_shell = False
 
     def fake_popen(cmd: str, shell: bool) -> SimpleNamespace:
-        captured["cmd"] = cmd
-        captured["shell"] = shell
+        nonlocal captured_cmd, captured_shell
+        captured_cmd = cmd
+        captured_shell = shell
         return SimpleNamespace()
 
     monkeypatch.setattr(ssh_module, "Popen", fake_popen)
@@ -64,6 +66,6 @@ def test_thread_exe_command_builds_ssh_command(
 
     thread.exe_command()
 
-    assert captured["shell"] is True
-    assert "ssh dummy-host 'source .profile ; echo hello;'" in captured["cmd"]
-    assert "ssh dummy-host 'source .profile ;  echo world;'" in captured["cmd"]
+    assert captured_shell is True
+    assert "ssh dummy-host 'source .profile ; echo hello;'" in captured_cmd
+    assert "ssh dummy-host 'source .profile ;  echo world;'" in captured_cmd

--- a/tests/test_eio.py
+++ b/tests/test_eio.py
@@ -2,9 +2,8 @@
 import json
 import os
 from pathlib import Path
-from typing import Callable, Generator
+from typing import Any, Callable, Literal
 
-import numpy as np
 import pandas as pd
 import pytest
 
@@ -39,7 +38,7 @@ def made_dir_name() -> str:
 
 
 def make_sample(
-    out_dir: str = "./",
+    out_dir: str | Path = "./",
     header: str | None = None,
     param_flag: bool = True,
     header_flag: bool = True,
@@ -49,18 +48,13 @@ def make_sample(
     error_display: bool = False,
     sort_keys: bool = True,
     ensure_ascii: bool = False,
-    mkdir: str = "off",
+    mkdir: Literal["shallow", "deep", "on", "off"] = "off",
     indent: int = 4,
-    default: Callable[
-        [np.float32 | np.int64 | np.ndarray], float | int | list[int | float]
-    ] = support_numpy,
-    tail_param: tuple[str] = ("_seed",),
-) -> Callable[
-    [list[int], str, float, int],
-    tuple[dict, pd.DataFrame, dict, pd.DataFrame, pd.DataFrame],
-]:
+    default: Callable[[Any], float | int | list[Any]] = support_numpy,
+    tail_param: tuple[str, ...] = ("_seed",),
+) -> Callable[..., Any]:
     @eio(
-        out_dir=out_dir,
+        out_dir=str(out_dir),
         header=header,
         param_flag=param_flag,
         header_flag=header_flag,
@@ -72,15 +66,15 @@ def make_sample(
         ensure_ascii=ensure_ascii,
         mkdir=mkdir,
         indent=indent,
-        default=support_numpy,
+        default=default,
         tail_param=tail_param,
     )
     def sample(
-        hidden_layer_sizes: tuple,
+        hidden_layer_sizes: tuple[int, ...] | list[int],
         activation: str,
         validation_fraction: float,
         _seed: int,
-    ) -> tuple[dict, pd.DataFrame, dict, pd.DataFrame, pd.DataFrame]:
+    ) -> tuple[dict[str, Any], pd.DataFrame, dict[str, Any], pd.DataFrame, pd.DataFrame]:
         dict_out = {
             "a": [a * 2 for a in hidden_layer_sizes],
             "b": "___" + activation + "___",
@@ -98,7 +92,7 @@ def make_sample(
     return sample
 
 
-def assert_json(result: dict[str, dict[str, list[int] | str | float]]) -> None:
+def assert_json(result: dict[str, Any]) -> None:
     assert result["a"][0] == 200
     assert result["a"][1] == 400
     assert result["b"] == "___relu___"
@@ -116,7 +110,7 @@ def assert_df(df: pd.DataFrame) -> None:
     assert df["c"][0] == pytest.approx(0.3)
 
 
-def assert_eio(*args: list[Path]) -> None:
+def assert_eio(*args: Path) -> None:
     for filepath in args:
         ext = os.path.splitext(filepath)[1]
         if ext == ".json":
@@ -132,7 +126,7 @@ def assert_eio(*args: list[Path]) -> None:
 def test_eio_smoke(
     param: dict[str, list[int] | str | float | int],
     filenames: list[str],
-    tmp_dir: Generator[Path, None, None],
+    tmp_dir: Path,
 ) -> None:
     out_dir = tmp_dir
     sample = make_sample(out_dir=out_dir, display=False)
@@ -145,7 +139,7 @@ def test_eio_mkdir_on(
     param: dict[str, list[int] | str | float | int],
     filenames: list[str],
     made_dir_name: str,
-    tmp_dir: Generator[Path, None, None],
+    tmp_dir: Path,
 ) -> None:
     out_dir = tmp_dir
     mk_dir_path = out_dir / made_dir_name
@@ -161,7 +155,7 @@ def test_eio_mkdir_shallow(
     param: dict[str, list[int] | str | float | int],
     filenames: list[str],
     made_dir_name: str,
-    tmp_dir: Generator[Path, None, None],
+    tmp_dir: Path,
 ) -> None:
     out_dir = tmp_dir
     mk_dir_path = out_dir / made_dir_name
@@ -182,7 +176,7 @@ def test_eio_mkdir_deep(
     param: dict[str, list[int] | str | float | int],
     filenames: list[str],
     made_dir_name: str,
-    tmp_dir: Generator[Path, None, None],
+    tmp_dir: Path,
 ) -> None:
     out_dir = tmp_dir
     mk_dir_path = out_dir / made_dir_name

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -6,7 +6,7 @@ from sekit.search import search
 
 def test_search(
     search_filepath_list: list[str],
-    out_func_hoge_piyo: tuple[str, Callable[dict, int]],
+    out_func_hoge_piyo: tuple[str, Callable[[dict[str, int]], int]],
 ) -> None:
     df = search(search_filepath_list, out_funcs=(out_func_hoge_piyo,))
     assert len(df) == 42

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -11,7 +11,7 @@ from sekit.stats import stats
 
 def test_stats(
     search_filepath_list: list[str],
-    out_func_hoge_piyo: tuple[str, Callable[dict[str, int], int]],
+    out_func_hoge_piyo: tuple[str, Callable[[dict[str, int]], int]],
 ) -> None:
     df = search(search_filepath_list, out_funcs=(out_func_hoge_piyo,))
     stats_df = stats(df)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -80,7 +80,7 @@ def test_make_param_str(param: dict[str, Any]) -> None:
     assert param_str == "_s=2525,a=relu,hls=100_200,vf=0.1"
 
     pe = ParamEncoder()
-    pe.fit(param)
+    pe.fit(list(param.keys()))
     param_str = make_param_str(param, param_encoder=pe)
     assert param_str == "_s=2525,a=relu,hls=100_200,vf=0.1"
 
@@ -98,8 +98,8 @@ def test_make_param_str(param: dict[str, Any]) -> None:
 )
 def test_support_numpy(
     test_input: np.float32 | np.int64 | np.ndarray,
-    expected_value: float | int | list,
-    expected_type: type[float] | type[int] | type[list],
+    expected_value: float | int | list[int],
+    expected_type: type[Any],
 ) -> None:
     actual = support_numpy(test_input)
     assert actual == expected_value


### PR DESCRIPTION
## Summary
- update test type annotations to satisfy strict mypy checks
- update examples typing to satisfy strict mypy checks
- keep runtime behavior unchanged while fixing strict typing issues

## Verification
- uv run mypy --strict tests
- uv run mypy --strict examples
- uv run ruff check
- uv run pytest