### PR TITLE
Remove exec-based CLI overrides in Spartan entrypoints

### DIFF
--- a/sekit/spartan/__main__.py
+++ b/sekit/spartan/__main__.py
@@ -35,12 +35,23 @@ def main() -> None:
     config_filepath = option.get("config_filepath", "")
     display = option.get("display", True)
 
-    # Overwrite command line parameters if setted them.
-    for k, v in args.__dict__.items():
-        if v is None:
-            continue
-        v = "'" + v + "'" if isinstance(v, str) else v
-        exec("{} = {}".format(k, v))
+    # Overwrite option values only when CLI args are explicitly provided.
+    if args.mode is not None:
+        mode = args.mode
+    if args.n_seeds is not None:
+        n_seeds = args.n_seeds
+    if args.max_size is not None:
+        maxsize = args.max_size
+    if args.interval is not None:
+        interval = args.interval
+    if args.seed_key is not None:
+        seed_key = args.seed_key
+    if args.max_seed is not None:
+        max_seed = args.max_seed
+    if args.config_filepath is not None:
+        config_filepath = args.config_filepath
+    if args.display is not None:
+        display = args.display
     sc = SpartanController(hosts, mode=mode)
     sc.exe(
         command,

--- a/sekit/spartan/spartan
+++ b/sekit/spartan/spartan
@@ -34,12 +34,23 @@ if __name__ == '__main__':
     config_filepath = option.get('config_filepath', '')
     display = option.get('display', True)
 
-    # Overwrite command line parameters if setted them.
-    for k, v in args.__dict__.items():
-        if v is None:
-            continue
-        v = "'" + v + "'" if type(v) == str else v
-        exec('{} = {}'.format(k, v))
+    # Overwrite option values only when CLI args are explicitly provided.
+    if args.mode is not None:
+        mode = args.mode
+    if args.n_seeds is not None:
+        n_seeds = args.n_seeds
+    if args.max_size is not None:
+        maxsize = args.max_size
+    if args.interval is not None:
+        interval = args.interval
+    if args.seed_key is not None:
+        seed_key = args.seed_key
+    if args.max_seed is not None:
+        max_seed = args.max_seed
+    if args.config_filepath is not None:
+        config_filepath = args.config_filepath
+    if args.display is not None:
+        display = args.display
     sc = SpartanController(hosts, mode=mode)
     sc.exe(command, param_grid,
            n_seeds=n_seeds, maxsize=maxsize, interval=interval,


### PR DESCRIPTION
## Summary
- replace exec-based CLI override logic with explicit assignments
- keep current CLI option precedence (CLI values override file option values)
- apply the same fix to both Spartan entrypoint scripts

## Why
- removes code-injection risk introduced by dynamic exec
- makes override behavior explicit and easier to maintain

## Verification
- uv run ruff check
- uv run mypy --strict sekit tests examples
- uv run pytest