### PR TITLE
Fix Spartan --display parsing with explicit boolean flags

### DIFF
--- a/sekit/spartan/__main__.py
+++ b/sekit/spartan/__main__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from argparse import ArgumentParser
+from argparse import ArgumentParser, BooleanOptionalAction
 
 from ..utils import load_yaml_or_json
 from .Spartan import SpartanController
@@ -16,7 +16,9 @@ def main() -> None:
     parser.add_argument("--seed_key")
     parser.add_argument("--max_seed", type=int)
     parser.add_argument("--config_filepath")
-    parser.add_argument("--display", type=bool)
+    parser.add_argument(
+        "--display", action=BooleanOptionalAction, default=None
+    )
 
     args = parser.parse_args()
     input_dict = load_yaml_or_json(args.filepath)

--- a/sekit/spartan/spartan
+++ b/sekit/spartan/spartan
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from argparse import ArgumentParser
+from argparse import ArgumentParser, BooleanOptionalAction
 
 from ..utils import load_yaml_or_json
 from .SpartanController import SpartanController
@@ -15,7 +15,9 @@ if __name__ == '__main__':
     parser.add_argument('--seed_key')
     parser.add_argument('--max_seed', type=int)
     parser.add_argument('--config_filepath')
-    parser.add_argument('--display', type=bool)
+    parser.add_argument(
+        '--display', action=BooleanOptionalAction, default=None
+    )
 
     args = parser.parse_args()
     input_dict = load_yaml_or_json(args.filepath)


### PR DESCRIPTION
## Summary
- replace `--display` `type=bool` parsing with `BooleanOptionalAction`
- support explicit CLI flags: `--display` and `--no-display`
- keep precedence behavior: CLI overrides config only when specified

## Why
- `type=bool` in argparse is error-prone (e.g. `--display False` can evaluate truthy)
- explicit boolean optional flags make behavior predictable

## Verification
- uv run ruff check
- uv run mypy --strict sekit tests examples
- uv run pytest