### PR TITLE
Fix legacy Spartan script import path

### DIFF
--- a/sekit/spartan/spartan
+++ b/sekit/spartan/spartan
@@ -3,7 +3,7 @@
 from argparse import ArgumentParser, BooleanOptionalAction
 
 from ..utils import load_yaml_or_json
-from .SpartanController import SpartanController
+from .Spartan import SpartanController
 
 if __name__ == '__main__':
     parser = ArgumentParser(description='')


### PR DESCRIPTION
## Summary
- fix legacy `sekit/spartan/spartan` script import to use `.Spartan`
- align legacy script with current module layout and `sekit/spartan/__main__.py`

## Verification
- uv run ruff check
- uv run mypy --strict sekit tests examples
- uv run pytest