### PR TITLE
Remove shell=True from Spartan subprocess execution

### DIFF
--- a/sekit/spartan/ComputeNode.py
+++ b/sekit/spartan/ComputeNode.py
@@ -3,6 +3,7 @@ import time
 from collections import OrderedDict
 from multiprocessing import cpu_count
 from queue import Empty, Queue
+from shlex import split as shlex_split
 from subprocess import Popen
 from threading import Lock, Thread, current_thread
 from typing import Any, Iterable, Sequence, cast
@@ -56,7 +57,7 @@ class ComputeNodeThread(Thread):
         self._continue = False
 
     def exe_command(self) -> Popen[Any]:
-        return Popen(cast(str, self.cmd), shell=True)
+        return Popen(shlex_split(cast(str, self.cmd)))
 
 
 class ComputeNode:

--- a/sekit/spartan/SshComputeNode.py
+++ b/sekit/spartan/SshComputeNode.py
@@ -16,12 +16,13 @@ class SshComputeNodeThread(ComputeNodeThread):
         self.p_cn: "SshComputeNode" = p_cn
 
     def exe_command(self) -> Popen[Any]:
-        ssh_header = "ssh " + self.p_cn.hostname + " "
-        out_cmd = ""
-        for c in cast(str, self.cmd).strip(" ;").split(";"):
-            one_cmd = ssh_header + "'{} ; {};'".format(self.p_cn.pre_cmd, c)
-            out_cmd += one_cmd + " ; "
-        return Popen(out_cmd, shell=True)
+        commands = [
+            c.strip() for c in cast(str, self.cmd).strip(" ;").split(";")
+        ]
+        remote_cmd = " ; ".join(
+            "{} ; {};".format(self.p_cn.pre_cmd, c) for c in commands if c
+        )
+        return Popen(["ssh", self.p_cn.hostname, remote_cmd])
 
 
 class SshComputeNode(ComputeNode):

--- a/sekit/spartan/SshComputeNode.py
+++ b/sekit/spartan/SshComputeNode.py
@@ -19,9 +19,17 @@ class SshComputeNodeThread(ComputeNodeThread):
         commands = [
             c.strip() for c in cast(str, self.cmd).strip(" ;").split(";")
         ]
-        remote_cmd = " ; ".join(
-            "{} ; {};".format(self.p_cn.pre_cmd, c) for c in commands if c
-        )
+        remote_cmds: list[str] = []
+        for command in commands:
+            if not command:
+                continue
+            if self.p_cn.pre_cmd:
+                remote_cmds.append(
+                    "{} ; {}".format(self.p_cn.pre_cmd, command)
+                )
+            else:
+                remote_cmds.append(command)
+        remote_cmd = " ; ".join(remote_cmds)
         return Popen(["ssh", self.p_cn.hostname, remote_cmd])
 
 

--- a/tests/spartan/test_ssh_compute_node_unit.py
+++ b/tests/spartan/test_ssh_compute_node_unit.py
@@ -48,13 +48,11 @@ def test_start_thread_uses_ssh_thread_without_network(
 def test_thread_exe_command_builds_ssh_command(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured_cmd = ""
-    captured_shell = False
+    captured_cmd: list[str] = []
 
-    def fake_popen(cmd: str, shell: bool) -> SimpleNamespace:
-        nonlocal captured_cmd, captured_shell
+    def fake_popen(cmd: list[str]) -> SimpleNamespace:
+        nonlocal captured_cmd
         captured_cmd = cmd
-        captured_shell = shell
         return SimpleNamespace()
 
     monkeypatch.setattr(ssh_module, "Popen", fake_popen)
@@ -66,6 +64,7 @@ def test_thread_exe_command_builds_ssh_command(
 
     thread.exe_command()
 
-    assert captured_shell is True
-    assert "ssh dummy-host 'source .profile ; echo hello;'" in captured_cmd
-    assert "ssh dummy-host 'source .profile ;  echo world;'" in captured_cmd
+    assert captured_cmd[0] == "ssh"
+    assert captured_cmd[1] == "dummy-host"
+    assert "source .profile ; echo hello;" in captured_cmd[2]
+    assert "source .profile ; echo world;" in captured_cmd[2]

--- a/tests/spartan/test_ssh_compute_node_unit.py
+++ b/tests/spartan/test_ssh_compute_node_unit.py
@@ -66,5 +66,6 @@ def test_thread_exe_command_builds_ssh_command(
 
     assert captured_cmd[0] == "ssh"
     assert captured_cmd[1] == "dummy-host"
-    assert "source .profile ; echo hello;" in captured_cmd[2]
-    assert "source .profile ; echo world;" in captured_cmd[2]
+    assert "source .profile ; echo hello" in captured_cmd[2]
+    assert "source .profile ; echo world" in captured_cmd[2]
+    assert " ; ; " not in captured_cmd[2]


### PR DESCRIPTION
## Summary
- update ComputeNodeThread to execute commands without shell=True
- update SshComputeNodeThread to invoke ssh with argument lists instead of shell command strings
- adjust unit test expectations for the new Popen invocation shape

## Verification
- uv run ruff check
- uv run mypy --strict sekit tests examples
- uv run pytest